### PR TITLE
fix typo of `nvar` in `smooth.basis1()`

### DIFF
--- a/R/smooth.basis1.R
+++ b/R/smooth.basis1.R
@@ -310,7 +310,7 @@ smooth.basis1 <- function (argvals=1:n, y, fdParobj,
         if (ndim==2) {
           coef <- solve(basismat, y)
         } else {
-          for (ivar in 1:var)
+          for (ivar in 1:nvar)
             coef[1:n, , ivar] <- solve(basismat, y[,,ivar])
         }
         penmat  <- NULL
@@ -460,7 +460,7 @@ smooth.basis1 <- function (argvals=1:n, y, fdParobj,
         if (ndim==2){
           coef <- solve(basismat, y)
         } else {
-          for (ivar in 1:var)
+          for (ivar in 1:nvar)
             coef[,,ivar] <- solve(basismat, y[,,ivar])
         }
         penmat <- NULL


### PR DESCRIPTION
I encountered a bug due to what I think was a typo in `smooth.basis1()` where `1:nvar` is sometimes `1:var` instead. While `nvar` is defined (and used correctly in other for loops), `var` is just the function `stats::var()` - this caused a cryptic error `Error in 1:var : NA/NaN argument` when the function was called internally via `smooth.basis()`.

Thanks!